### PR TITLE
ci: add workflow to sync upstream master daily

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,27 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    # Runs daily at 00:00 UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Sync upstream master
+        run: |
+          git remote add upstream https://github.com/geogenesis-network/geogenesis.git
+          git fetch upstream master
+          git merge upstream/master --no-edit
+          git push origin master


### PR DESCRIPTION
Adds a GitHub Action that runs daily (and on manual trigger) to fetch and merge the upstream geogenesis-network/geogenesis master branch into this fork's master branch.